### PR TITLE
サーバー側でCORSを設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.5)
@@ -153,6 +155,7 @@ DEPENDENCIES
   byebug
   listen (~> 3.2)
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.3, >= 6.0.3.5)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'http://localhost:3001'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/frontend/src/containers/Restaurants.jsx
+++ b/frontend/src/containers/Restaurants.jsx
@@ -1,4 +1,4 @@
-import from, { Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import { fetchRestaurants } from '../apis/restaurants';
 
 export const Restaurants = () => {

--- a/frontend/src/urls/index.js
+++ b/frontend/src/urls/index.js
@@ -1,5 +1,5 @@
 // サーバーサイドで定義したURL文字列を返す定数をいくつか設定
-const DEFAULT_API_LOCALHOST = 'http://localhost:3000/api/vi'
+const DEFAULT_API_LOCALHOST = 'http://localhost:3000/api/v1'
 
 export const restaurantsIndex = `${DEFAULT_API_LOCALHOST}/restaurants`
 export const foodsIndex = (restaurantId) =>


### PR DESCRIPTION
一般的にクロスオリジン間でのリソースの共有はセキュリティの観点から禁止されており、これを意図的に許容させるためCORSを設定